### PR TITLE
Symlink dircolors to standard dircolors file targets

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -48,7 +48,6 @@ declare -a FILES_TO_SYMLINK=(
   'git/main.gitconfig'
   'git/gitignore'
 
-  'shell/dircolors.256dark'
   'shell/ignore'
   'shell/tmux.conf'
   'shell/zshrc'
@@ -172,7 +171,7 @@ unlink_file() {
   fi
 }
 
-# Symlink (or unlink) the dotfiles.
+# Symlink (or unlink) the root dotfiles.
 for i in "${FILES_TO_SYMLINK[@]}"; do
   sourceFile="$(pwd)/$i"
   targetFile="$HOME/.$(printf "%s" "$i" | sed "s/.*\/\(.*\)/\1/g")"
@@ -184,6 +183,7 @@ for i in "${FILES_TO_SYMLINK[@]}"; do
   fi
 done
 
+# Symlink (or unlink) the non-root dotfiles.
 for i in "${FULL_PATH_FILES_TO_SYMLINK[@]}"; do
   sourceFile="$(pwd)/$i"
   targetFile="$HOME/.$i"
@@ -195,6 +195,18 @@ for i in "${FULL_PATH_FILES_TO_SYMLINK[@]}"; do
     unlink_file $sourceFile $targetFile
   fi
 done
+
+# Symlink (or unlink) the dircolors files.
+if [[ $BUILD ]]; then
+  sourceFile="$(pwd)/shell/dircolors.256dark"
+  link_file $sourceFile "$HOME/.dircolors"
+  link_file $sourceFile "$HOME/.dir_colors"
+else
+  # Unlink the dircolors files.
+  sourceFile="$(pwd)/shell/dircolors.256dark"
+  unlink_file $sourceFile "$HOME/.dircolors"
+  unlink_file $sourceFile "$HOME/.dir_colors"
+fi
 
 if [[ $BUILD ]]; then
   # Install zsh (if not available) and oh-my-zsh and p10k.

--- a/shell/zshrc
+++ b/shell/zshrc
@@ -168,8 +168,6 @@ if _has fzf; then
 fi
 
 # Dircolors must be set last, since oh-my-zsh seems to rewrite those values.
-if [[ "$(uname -s)" == "Linux" ]]; then
-  eval `dircolors ~/.dircolors.256dark`;
-else
+if [[ "$(uname -s)" == "Darwin" ]]; then
   LSCOLORS='ExFxBxDxCxegedabagacad'
 fi


### PR DESCRIPTION
Now `shell/dircolors.256dark` will be the source for `~/.dircolors` and `~/dir_colors`. The `configure.sh` script also gets cleaned up a bit.

A few things to note:
* I no longer source `~/.dircolors.256dark`. I need to verify that this is okay for non-Ubuntu Linux machines.
* `configure.sh` underwent a refactor. I need verify that there are no regressions.
* I should also resolve which types of machines need some dircolor config files (as opposed to the manual sourcing of the files) and what the standard file names ought to be.

After that I can merge this PR and mark #7 as completed.