### PR TITLE
Support a ~/.ignore file

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -50,6 +50,7 @@ declare -a FILES_TO_SYMLINK=(
 
   'shell/dircolors.256dark'
   'shell/gdbinit'
+  'shell/ignore'
   'shell/tmux.conf'
   'shell/zshrc'
 

--- a/shell/ignore
+++ b/shell/ignore
@@ -1,5 +1,11 @@
+# Common folders
 .git/
 node_modules/
-.DS_Store
-*.swp
 Library/
+
+# Common artifact files
+.DS_Store
+.localized
+
+# Vim swapfiles
+*.swp

--- a/shell/ignore
+++ b/shell/ignore
@@ -1,0 +1,5 @@
+.git/
+node_modules/
+.DS_Store
+*.swp
+Library/

--- a/shell/zshrc
+++ b/shell/zshrc
@@ -120,7 +120,7 @@ if _has fzf; then
 
   if _has fd; then
     # Use fd for fzf.
-    export FZF_DEFAULT_COMMAND='fd --type f --follow --hidden --exclude .git'
+    export FZF_DEFAULT_COMMAND='fd --type f --follow --hidden'
   elif _has rg; then
     # Use ripgrep for fzf.
     export FZF_DEFAULT_COMMAND='rg --files --hidden'


### PR DESCRIPTION
We're linking a `~/.ignore` file for `rg`, `ag`, `fd`, `ack`, and many other tools.

Fixes #27.
