### PR TITLE
Refresh zsh completions upon opening a shell

### DIFF
--- a/shell/zshrc
+++ b/shell/zshrc
@@ -104,6 +104,9 @@ fi
 # Source Oh-My-ZSH.
 source $ZSH/oh-my-zsh.sh
 
+# Update completion scripts (which should be defined by homebrew and oh-my-zsh).
+rm -f ~/.zcompdump && compinit
+
 # Configure fzf (if available).
 if _has fzf; then
   # Source fzf key bindings and auto-completion.


### PR DESCRIPTION
Homebrew zsh completions weren't working. Turns out I need to flush the cache every time I start a new shell.

```shell
rm -f ~/.zcompdump && compinit
```