### PR TITLE
Map enter key to open up fzf windows

### DIFF
--- a/editor/vimrc
+++ b/editor/vimrc
@@ -108,6 +108,9 @@ if executable('fzf')
 
   command! -bang -nargs=? -complete=dir Files
     \ call fzf#vim#files(<q-args>, fzf#vim#with_preview(), <bang>0)
+
+  " Remap ctrl-m (and enter key) to toggle open files.
+  nnoremap <silent> <C-m> :Windows<CR>
 endif
 
 if executable('rg')


### PR DESCRIPTION
Pressing ctrl-m or the enter key will allow fuzzy finding among open files in vim.