### PR TITLE
Fix setup symlink handling and run ShellCheck on pull requests

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,5 +1,9 @@
 name: Shellcheck
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - "master"
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,5 +1,5 @@
 name: Shellcheck
-on: [push]
+on: [push, pull_request]
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/setup.sh
+++ b/setup.sh
@@ -227,7 +227,12 @@ link_file() {
   local current_target
   local epoch
 
-  current_target=$(readlink "${target}" 2>/dev/null)
+  if [[ -L "${target}" ]]; then
+    current_target=$(readlink "${target}")
+  else
+    current_target=""
+  fi
+
   if [[ "${current_target}" == "${source}" ]]; then
     return
   fi
@@ -245,7 +250,12 @@ unlink_file() {
   local target=$2
   local current_target
 
-  current_target=$(readlink "${target}" 2>/dev/null)
+  if [[ -L "${target}" ]]; then
+    current_target=$(readlink "${target}")
+  else
+    current_target=""
+  fi
+
   if [[ "${current_target}" == "${source}" ]]; then
     execute "Unlinking ${target} → ${source}" unlink "${target}"
   fi


### PR DESCRIPTION
## Summary
- guard `readlink` in `setup.sh` so missing targets do not abort fresh installs or cleanups under `set -e`
- run ShellCheck on `pull_request` in addition to `push` so shell regressions are caught before merge

## Testing
- `bash -n setup.sh scripts/*.sh`
- `zsh -n home/zshenv home/zshrc home/p10k.zsh`